### PR TITLE
Add files via upload

### DIFF
--- a/Source/AthenaFramework/CompAbilityEffect_ConeShoot.cs
+++ b/Source/AthenaFramework/CompAbilityEffect_ConeShoot.cs
@@ -1,0 +1,160 @@
+using System.Collections.Generic;
+using RimWorld;
+using RimWorld.Planet;
+using Verse;
+using UnityEngine;
+using System;
+using System.Linq;
+using VFECore.Abilities;
+
+namespace VFECore.Abilities
+{
+public class CompAbilityEffect_ConeShoot : CompAbilityEffect
+{
+	private List<IntVec3> tmpCells = new List<IntVec3>();
+
+	private new CompProperties_AbilityConeShoot Props => (CompProperties_AbilityConeShoot)props;
+
+	private Pawn Pawn => parent.pawn;
+
+	public override void Apply(LocalTargetInfo target, LocalTargetInfo dest)
+	{
+		IntVec3 position = parent.pawn.Position;
+		float num = Mathf.Atan2(-(target.Cell.z - position.z), target.Cell.x - position.x) * 57.29578f;
+		GenExplosion.DoExplosion(affectedAngle: new FloatRange(num - Props.angle/2f, num + Props.angle/2f), center: position, map: parent.pawn.MapHeld, radius: Props.range, damType: Props.damageDef, instigator: Pawn, damAmount: Props.damage, armorPenetration: Props.armorPenetration, explosionSound: null, weapon: null, projectile: null, intendedTarget: null, postExplosionSpawnThingDef: Props.spawnThingDef, postExplosionSpawnChance: Props.spawnThingChance, postExplosionSpawnThingCount: 1, postExplosionGasType: Props.spawnGasDef, applyDamageToExplosionCellsNeighbors: false, preExplosionSpawnThingDef: null, preExplosionSpawnChance: 0f, preExplosionSpawnThingCount: 1, chanceToStartFire: Props.chanceToStartFire, damageFalloff: false, direction: null, ignoredThings: null, doVisualEffects: false, propagationSpeed: Props.propagationSpeed, excludeRadius: Props.minRange, doSoundEffects: false);
+		// Log.Message("range is " + Props.range);
+		// List<IntVec3> AoECells = GenRadial.RadialCellsAround(position, Props.range, false).ToList();
+		// Log.Message("AoECells has " + AoECells.Count);
+		// if (Props.minRange > 0)
+		// {
+			// AoECells = AoECells.Except(GenRadial.RadialCellsAround(position, Props.minRange, false).ToList()).ToList();
+		// }
+		// Log.Message("AoECells has " + AoECells.Count);
+		// float width = Props.angle;
+		// List<IntVec3> ConeCells = new List<IntVec3>();
+		// foreach (IntVec3 c in AoECells)
+		// {
+			// Log.Message("angle: " + Math.Abs(Mathf.Atan2(-(c.z - position.z), c.x - position.x) * 57.29578f) + " ; width : " + width);
+			// if (Math.Abs(Mathf.Atan2(-(c.z - position.z), c.x - position.x) * 57.29578f) < width)
+			// {
+				// ConeCells.Add(c);
+				// Log.Message("added a cell to ConeCells");
+			// }
+		// }
+		// foreach (IntVec3 c in ConeCells)
+		// {
+			// Projectile newProjectile = (Projectile)GenSpawn.Spawn(WP_DefOf.WP_ProjectileTectonicShockwave, position, parent.pawn.MapHeld, WipeMode.Vanish);
+            // newProjectile.Launch(parent.pawn, c, c, ProjectileHitFlags.IntendedTarget, false, null);
+			// Log.Message("shot");
+		// }
+		base.Apply(target, dest);
+	}
+
+	public override void DrawEffectPreview(LocalTargetInfo target)
+	{
+		//Log.Message("drawing field edges");
+		GenDraw.DrawFieldEdges(AffectedCells(target));
+	}
+
+	public override bool AICanTargetNow(LocalTargetInfo target)
+	{
+		if (Pawn.Faction != null)
+		{
+			foreach (IntVec3 item in AffectedCells(target))
+			{
+				List<Thing> thingList = item.GetThingList(Pawn.Map);
+				for (int i = 0; i < thingList.Count; i++)
+				{
+					if (thingList[i].Faction == Pawn.Faction)
+					{
+						return false;
+					}
+				}
+			}
+		}
+		return true;
+	}
+
+	private List<IntVec3> AffectedCells(LocalTargetInfo target)
+	{
+		tmpCells.Clear();
+		Vector3 vector = Pawn.Position.ToVector3Shifted().Yto0();
+		IntVec3 intVec = target.Cell.ClampInsideMap(Pawn.Map);
+		if (Pawn.Position == intVec)
+		{
+			return tmpCells;
+		}
+		float lengthHorizontal = (intVec - Pawn.Position).LengthHorizontal;
+		float num = (float)(intVec.x - Pawn.Position.x) / lengthHorizontal;
+		float num2 = (float)(intVec.z - Pawn.Position.z) / lengthHorizontal;
+		intVec.x = Mathf.RoundToInt((float)Pawn.Position.x + num * Props.range);
+		intVec.z = Mathf.RoundToInt((float)Pawn.Position.z + num2 * Props.range);
+		float target2 = Vector3.SignedAngle(intVec.ToVector3Shifted().Yto0() - vector, Vector3.right, Vector3.up);
+		float num3 = Props.lineWidthEnd / 2f;
+		float num4 = Mathf.Sqrt(Mathf.Pow((intVec - Pawn.Position).LengthHorizontal, 2f) + Mathf.Pow(num3, 2f));
+		float num5 = 57.29578f * Mathf.Asin(num3 / num4);
+		int num6 = GenRadial.NumCellsInRadius(Props.range);
+		for (int i = 0; i < num6; i++)
+		{
+			IntVec3 intVec2 = Pawn.Position + GenRadial.RadialPattern[i];
+			if (CanUseCell(intVec2) && Mathf.Abs(Mathf.DeltaAngle(Vector3.SignedAngle(intVec2.ToVector3Shifted().Yto0() - vector, Vector3.right, Vector3.up), target2)) <= num5)
+			{
+				tmpCells.Add(intVec2);
+			}
+		}
+		List<IntVec3> list = GenSight.BresenhamCellsBetween(Pawn.Position, intVec);
+		for (int j = 0; j < list.Count; j++)
+		{
+			IntVec3 intVec3 = list[j];
+			if (!tmpCells.Contains(intVec3) && CanUseCell(intVec3))
+			{
+				tmpCells.Add(intVec3);
+			}
+		}
+		return tmpCells;
+		bool CanUseCell(IntVec3 c)
+		{
+			if (!c.InBounds(Pawn.Map))
+			{
+				return false;
+			}
+			if (c == Pawn.Position)
+			{
+				return false;
+			}
+			if (c.Filled(Pawn.Map))
+			{
+				return false;
+			}
+			if (!c.InHorDistOf(Pawn.Position, Props.range))
+			{
+				return false;
+			}
+			return GenSight.LineOfSight(Pawn.Position, c, Pawn.Map, skipFirstCell: true);
+		}
+	}
+}
+
+public class CompProperties_AbilityConeShoot : CompProperties_AbilityEffect
+{
+	public float range;
+
+	public float lineWidthEnd;
+
+	public float angle;				//will be halved in calculations so it shoots 10° to one side and 10° to the other
+	public int damage;			
+	public DamageDef damageDef;		
+	public float armorPenetration;	
+	public float propagationSpeed;	//to not have instant "damage everything in this cone"
+	public float minRange;			//to have cones separate from the shooter
+	public ThingDef spawnThingDef;	//spawned post explosion
+	public float spawnThingChance;
+	public float chanceToStartFire;
+	public GasType spawnGasDef;	
+
+	public CompProperties_AbilityConeShoot()
+	{
+		compClass = typeof(CompAbilityEffect_ConeShoot);
+	}
+}
+}

--- a/Source/AthenaFramework/CompAbilityEffect_GiveHediffSeverity.cs
+++ b/Source/AthenaFramework/CompAbilityEffect_GiveHediffSeverity.cs
@@ -1,0 +1,76 @@
+// RimWorld.CompAbilityEffect_GiveHediff
+using RimWorld;
+using Verse;
+
+namespace MechAbility
+{
+	public class CompAbilityEffect_GiveHediffSeverity : CompAbilityEffect
+	{
+		public new CompProperties_AbilityGiveHediffSeverity Props => (CompProperties_AbilityGiveHediffSeverity)props;
+
+		public override void Apply(LocalTargetInfo target, LocalTargetInfo dest)
+		{
+			base.Apply(target, dest);
+			if (!Props.onlyApplyToSelf && Props.applyToTarget)
+			{
+				ApplyInner(target.Pawn, parent.pawn);
+			}
+			if (Props.applyToSelf || Props.onlyApplyToSelf)
+			{
+				ApplyInner(parent.pawn, target.Pawn);
+			}
+		}
+
+		protected void ApplyInner(Pawn target, Pawn other)
+		{
+			if (target == null)
+			{
+				return;
+			}
+			Hediff firstHediffOfDef = target.health.hediffSet.GetFirstHediffOfDef(Props.hediffDef);
+			if (Props.replaceExisting && firstHediffOfDef != null)
+			{
+				target.health.RemoveHediff(firstHediffOfDef);
+			}
+			Hediff hediff = HediffMaker.MakeHediff(Props.hediffDef, target, Props.onlyBrain ? target.health.hediffSet.GetBrain() : null);
+			
+			// HediffComp_Link hediffComp_Link = hediff.TryGetComp<HediffComp_Link>();
+			// if (hediffComp_Link != null)
+			// {
+				// hediffComp_Link.other = other;
+				// hediffComp_Link.drawConnection = target == parent.pawn;
+			// }
+			if (Props.replaceExisting || firstHediffOfDef == null)
+			{
+				target.health.AddHediff(hediff);
+			}
+			else
+			{
+				//firstHediffOfDef.severity += Props.severity;
+				HealthUtility.AdjustSeverity(target, firstHediffOfDef.def, Props.severity);
+			}
+		}
+	}
+
+	public class CompProperties_AbilityGiveHediffSeverity : CompProperties_AbilityEffect
+	{
+		public HediffDef hediffDef;
+
+		public bool onlyBrain;
+
+		public bool applyToSelf;
+
+		public bool onlyApplyToSelf;
+
+		public bool applyToTarget = true;
+
+		public bool replaceExisting;
+
+		public float severity = -1f;
+		
+		public CompProperties_AbilityGiveHediffSeverity()
+		{
+			compClass = typeof(CompAbilityEffect_GiveHediffSeverity);
+		}
+	}
+}

--- a/Source/AthenaFramework/CompCorpseDamagerToHD.cs
+++ b/Source/AthenaFramework/CompCorpseDamagerToHD.cs
@@ -1,0 +1,132 @@
+using RimWorld;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Verse.Sound;
+using Verse;
+
+namespace AnimalBehaviours
+{
+    public class CompCorpseDamagerToHD : ThingComp
+    {
+		//mostly taken from Sarg's Helixian Slug code
+        public int tickCounter = 0;
+        public bool flagOnce = false;
+		public bool shouldDecay;
+
+        public CompProperties_CorpseDamagerToHD Props
+        {
+            get
+            {
+                return (CompProperties_CorpseDamagerToHD)this.props;
+            }
+        }
+
+        public override void CompTick()
+        {
+            base.CompTick();
+
+			tickCounter++;
+
+			//Only check every 2 rare ticks (8 seconds)
+			if (tickCounter > Props.tickInterval)
+			{
+				Pawn pawn = this.parent as Pawn;
+
+				//Null map check
+				if (pawn.Map != null)
+				{
+					//Check on radius
+					CellRect rect = GenAdj.OccupiedRect(pawn.Position, pawn.Rotation, IntVec2.One);
+					rect = rect.ExpandedBy(Props.radius);
+
+					foreach (IntVec3 current in rect.Cells)
+					{
+						if (current.InBounds(pawn.Map))
+						{
+							HashSet<Thing> hashSet = new HashSet<Thing>(current.GetThingList(pawn.Map));
+							if (hashSet != null)
+							{
+								foreach (Thing thingInCell in hashSet)
+								{
+									Corpse corpse = thingInCell as Corpse;
+									//If anything in those cells was a corpse
+									if (corpse != null)
+									{
+										
+										//If it's a bug corpse and we care about bugs
+										if (corpse.InnerPawn.RaceProps.FleshType == FleshTypeDefOf.Insectoid && Props.hediffBugCorpse != null) 
+										{
+											HealthUtility.AdjustSeverity(pawn, Props.hediffBugCorpse, Props.severityGained); 
+											shouldDecay = true;
+										}
+										//If it's a human corpse and we care about humans
+										else if (corpse.InnerPawn.def.race.Humanlike && Props.hediffHumanCorpse != null) 
+										{
+											HealthUtility.AdjustSeverity(pawn, Props.hediffHumanCorpse, Props.severityGained); 
+											shouldDecay = true;
+										}
+										//If it's an animal corpse and we care about animals
+										else if (corpse.InnerPawn.RaceProps.Animal && Props.hediffBugCorpse != null)
+										{
+											HealthUtility.AdjustSeverity(pawn, Props.hediffAnimalCorpse, Props.severityGained); 
+											shouldDecay = true;
+										}
+										//If it's a mech corpse and we care about mechs
+										else if (corpse.InnerPawn.RaceProps.FleshType == FleshTypeDefOf.Mechanoid && Props.hediffMechCorpse != null) 
+										{
+											HealthUtility.AdjustSeverity(pawn, Props.hediffMechCorpse, Props.severityGained); 
+											shouldDecay = true;
+										}
+										//If the corpse reaches 0 HP, destroy it, and spawn corpse bile
+										if (shouldDecay) corpse.HitPoints -= Props.decayOnHitPoints;
+										shouldDecay = false;
+										if (corpse.HitPoints < 0)
+										{
+											corpse.Destroy(DestroyMode.Vanish);
+											for (int i = 0; i < 20; i++)
+											{
+												IntVec3 c;
+												CellFinder.TryFindRandomReachableCellNear(pawn.Position, pawn.Map, 2, TraverseParms.For(TraverseMode.NoPassClosedDoors, Danger.Deadly, false), null, null, out c);
+												FilthMaker.TryMakeFilth(c, pawn.Map, ThingDefOf.Filth_CorpseBile, pawn.LabelIndefinite(), 1, FilthSourceFlags.None);
+												SoundDef.Named(Props.corpseSound).PlayOneShot(new TargetInfo(pawn.Position, pawn.Map, false));
+											}
+										}
+										FilthMaker.TryMakeFilth(current, pawn.Map, ThingDefOf.Filth_CorpseBile, pawn.LabelIndefinite(), 1, FilthSourceFlags.None);
+										flagOnce = true;
+										break;	//exit foreach without looking at every other thing in the cell for speed
+									}
+								}
+							}
+						}
+						if (flagOnce && Props.findOneCorpsePerTickInterval) { flagOnce = false; break; }
+					}
+				}
+				tickCounter = 0;
+			}
+        }
+    }
+	public class CompProperties_CorpseDamagerToHD : CompProperties
+    {
+        
+        //A comp class to make a creature damage nearby corpses to gain hediff severity
+		//Can deal 0 damage to just be empowered by nearby corpses
+		//Can get different hediffs from different fleshTypes
+
+        public int radius = 5;
+        public int tickInterval = 500;
+        public int decayOnHitPoints = 1000;
+		public HediffDef hediffHumanCorpse;
+		public HediffDef hediffBugCorpse;
+		public HediffDef hediffAnimalCorpse;
+		public HediffDef hediffMechCorpse;
+		public bool findOneCorpsePerTickInterval = true;
+        public float severityGained = 1f;
+        public string corpseSound = "";
+
+        public CompProperties_CorpseDamagerToHD()
+        {
+            this.compClass = typeof(CompCorpseDamagerToHD);
+        }
+    }
+}

--- a/Source/AthenaFramework/CompInitialHediffIfFaction.cs
+++ b/Source/AthenaFramework/CompInitialHediffIfFaction.cs
@@ -1,0 +1,55 @@
+using Verse;
+
+namespace AnimalBehaviours
+{
+    public class CompInitialHediffIfFaction : ThingComp
+    {
+        private bool addHediffOnce = true;
+     
+        public CompProperties_InitialHediffIfFaction Props
+        {
+            get
+            {
+                return (CompProperties_InitialHediffIfFaction)this.props;
+            }
+        }
+
+        public override void PostExposeData()
+        {
+            base.PostExposeData();
+            Scribe_Values.Look<bool>(ref this.addHediffOnce, "addHediffOnce", true, false);
+        }
+
+        public override void CompTickRare()
+        {
+
+            base.CompTickRare();
+
+            //addHediffOnce is used (and saved) so the hediff is only added once when the creature spawns
+            if (addHediffOnce)
+            {
+                Pawn pawn = this.parent as Pawn;
+				if (Props.factionName == "" || pawn.Faction.def.defName == Props.factionName)
+				{
+					pawn.health.AddHediff(HediffDef.Named(Props.hediffName));               
+				}
+				addHediffOnce = false;
+            }
+        }
+    }
+	
+	public class CompProperties_InitialHediffIfFaction : CompProperties
+    {
+
+        //A comp class that makes animals always spawn with an initial Hediff if part of a faction
+
+        public string hediffName = "";
+		public string factionName;
+        public float hediffSeverity = 1f;
+
+        public CompProperties_InitialHediffIfFaction()
+        {
+            this.compClass = typeof(CompInitialHediffIfFaction);
+        }
+    }
+}

--- a/Source/AthenaFramework/HediffCompSummonFromHediffSeverity.cs
+++ b/Source/AthenaFramework/HediffCompSummonFromHediffSeverity.cs
@@ -1,0 +1,85 @@
+using RimWorld;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Verse;
+using Verse.Sound;
+using Verse.AI.Group;
+
+
+namespace AnimalBehaviours
+{
+    public class HediffCompSummonFromHediffSeverity : HediffComp
+    {
+        public int tickCounter = 0;
+
+        public HediffCompProperties_SummonFromHediffSeverity Props
+        {
+            get
+            {
+                return (HediffCompProperties_SummonFromHediffSeverity)this.props;
+            }
+        }
+
+        public override void CompPostTick(ref float severityAdjustment)
+        {
+            base.CompPostTick(ref severityAdjustment);
+            tickCounter++;
+            if (tickCounter > Props.tickInterval && this.parent.Severity >= Props.severityPerSummon)
+            {
+                if (this.parent.pawn.Map != null)
+                {
+                    int numToSpawn = Rand.RangeInclusive(Props.groupMinMax[0], Props.groupMinMax[1]);
+					Lord lord = ((this.parent.pawn is Pawn p) ? p.GetLord() : null);
+                    for (int i = 0; i < numToSpawn; i++)
+                    {
+						//string factionNameToMake = Props.factionToMake;
+						Faction factionToMake = this.parent.pawn.Faction; 
+						if (Props.factionToMake != "")
+						{
+							factionToMake = Find.FactionManager.FirstFactionOfDef(FactionDef.Named(Props.factionToMake));
+						}
+						PawnGenerationRequest request = new PawnGenerationRequest(PawnKindDef.Named(Props.pawnDef), factionToMake, PawnGenerationContext.NonPlayer, -1, false, false, false, false, true, 1f, false, false, true, true, false, false);
+						//if (factionNameToMake == "")
+						//{
+							//request = new PawnGenerationRequest(PawnKindDef.Named(Props.pawnDef), this.parent.pawn.Faction, PawnGenerationContext.NonPlayer, -1, false, false, false, false, true, 1f, false, false, true, true, false, false);
+							//factionNameToMake = this.parent.pawn.Faction.Name;
+							//or Faction.def.defName, not sure which is which
+						//}
+						//have a Faction variable that contains the Props value, if empty put in FirstFactionOfDef blabla, then generate
+						Pawn pawn = PawnGenerator.GeneratePawn(request);
+                        GenSpawn.Spawn(pawn, CellFinder.RandomClosewalkCellNear(this.parent.pawn.Position, this.parent.pawn.Map, 2, null), this.parent.pawn.Map, WipeMode.Vanish);
+                        lord?.AddPawn(pawn);
+						if (Props.summonsAreManhunters)
+                        {
+                            pawn.mindState.mentalStateHandler.TryStartMentalState(DefDatabase<MentalStateDef>.GetNamed("ManhunterPermanent", true), null, true, false, null, false);
+                        }
+                    }
+                    SoundDefOf.Hive_Spawn.PlayOneShot(new TargetInfo(this.parent.pawn.Position, this.parent.pawn.Map, false));
+					HealthUtility.AdjustSeverity(this.parent.pawn, this.parent.def, Props.severityPerSummon * -1);
+                }
+				tickCounter = 0;
+            }
+        }
+    }
+    public class HediffCompProperties_SummonFromHediffSeverity : HediffCompProperties
+    {
+
+        //A comp class to make an animal "summon" a configurable group of additional animals when spawned.
+        //For example a spider spawning with a host of smaller spiders. Similar to base game wild spawns, but
+        //with different defs
+
+        public string pawnDef;						//if unstated, summons a copy of the pawn; only looks nice on nonhumans
+        public List<int> groupMinMax;
+        public bool summonsAreManhunters;
+		public string factionToMake = "";			//if unstated, summons a pawn of the same faction as the spawner
+													//Hediffs have a property called source but I don't know what it refers to, sooo
+		public int tickInterval = 600;				//by default checks every ten seconds to reduce lag
+		public int severityPerSummon = 1;			//need at least that much, subtract that much from severity per summon
+
+        public HediffCompProperties_SummonFromHediffSeverity()
+        {
+            this.compClass = typeof(HediffCompSummonFromHediffSeverity);
+        }
+    }
+}

--- a/Source/AthenaFramework/Verb_CooldownJump.cs
+++ b/Source/AthenaFramework/Verb_CooldownJump.cs
@@ -1,0 +1,48 @@
+using RimWorld;
+using Verse;
+
+namespace MVCF.Verbs
+{
+	[DefOf]
+	public static class TCMechs_DefOf
+	{
+        public static ThingDef PawnJumper_FlambergeFlight;
+	}
+    public class Verb_CooldownJump : RimWorld.Verb_Jump
+    {
+		public int cooldown = 0;
+        protected override float EffectiveRange => verbProps.range;
+		
+		public override bool Available()
+		{
+			if (Find.TickManager.TicksGame > this.cooldown)
+			{
+				return true;
+			}
+			return false;
+		}
+        protected override bool TryCastShot()
+        {
+            if (!ModLister.HasActiveModWithName("Royalty") || !ModLister.HasActiveModWithName("Biotech"))
+            {
+                Log.ErrorOnce(
+                    "Items with jump capability are a Royalty/Biotech-specific game item. If you want to use this code please enable the DLC before calling it. See rules on the Ludeon forum for more info.",
+                    550187797);
+                return false;
+            }
+			
+            var casterPawn = CasterPawn;
+            var cell = currentTarget.Cell;
+            var map = casterPawn.Map;
+            var pawnFlyer = PawnFlyer.MakeFlyer(TCMechs_DefOf.PawnJumper_FlambergeFlight, casterPawn, cell, null, null, false);
+            if (pawnFlyer != null)
+            {
+                GenSpawn.Spawn(pawnFlyer, cell, map);
+				this.cooldown = Find.TickManager.TicksGame + 3600;	//60s cooldown
+                return true;
+            }
+			
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
GiveHediffSeverity is like the vanilla comp, except it adds to existing severity instead of replacing it. 
CorpseDamagerToHD is very versatile; it stacks a given hediff's severity according to the type of corpses around the thing with the comp. You can stack different hediffs according to whether there are mechs/human/bug/animal corpses around, damage them or not, only find one corpse/all corpses per check, and so on. Auto eat corpses, repair by melding with other dead mechs, get weaker around dead corpses. 
InitialHediffIfFaction is mostly there for Biotech mechs, so that only enemy/player mechs get a starting hediff. 
SummonFromHediffSeverity spawns a thing and consumes the hediff's severity to spawn it. 
Verb_CooldownJump is MVCF's jump but checks for an internal cooldown; it's only there because I didn't realize that an ability must also be integrated to a ThinkTree to be used. Maybe potentially useful? 
ConeShoot is very cool; it's basically the FireSpew comp from Biotech except usable for other things.