### PR TITLE
Fix hediff removal not removing ability

### DIFF
--- a/Source/AthenaFramework/Abilities/CompAbility_SingularTracker.cs
+++ b/Source/AthenaFramework/Abilities/CompAbility_SingularTracker.cs
@@ -25,11 +25,10 @@ namespace AthenaFramework
 
         public virtual void RemoveAbility()
         {
-            abilityCount--;
-
             if (abilityCount > 0)
             {
                 parent.pawn.abilities.abilities.Remove(parent);
+                abilityCount--;
             }
         }
     }


### PR DESCRIPTION
Removing a hediff doesn't remove the ability because the decrement drops the count to 0 so the removal is never triggered